### PR TITLE
For 1.6.0: change to [RMConfiguration sharedInstance]

### DIFF
--- a/Mapbox Example/AppDelegate.m
+++ b/Mapbox Example/AppDelegate.m
@@ -21,7 +21,7 @@
 {
     self.window = [[UIWindow alloc] initWithFrame:[[UIScreen mainScreen] bounds]];
 
-    [[RMConfiguration configuration] setAccessToken:@"pk.eyJ1IjoianVzdGluIiwiYSI6IlpDbUJLSUEifQ.4mG8vhelFMju6HpIY-Hi5A"];
+    [[RMConfiguration sharedInstance] setAccessToken:@"pk.eyJ1IjoianVzdGluIiwiYSI6IlpDbUJLSUEifQ.4mG8vhelFMju6HpIY-Hi5A"];
 
     UITabBarController *tabBarController = [[UITabBarController alloc] init];
     


### PR DESCRIPTION
`[RMConfiguration configuration]` was deprecated in 1.6.0.

Depends on #16.